### PR TITLE
Add image attribute output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The Action provides the following information as output:
 |     `name`      |                  The name of the add-on.                  |
 |     `slug`      |                The configured add-on slug.                |
 |    `target`     |                 The add-on target folder.                 |
+|    `image`      |              The Image-template of the addon              |
 
 ## Changelog & Releases
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The Action provides the following information as output:
 |     `name`      |                  The name of the add-on.                  |
 |     `slug`      |                The configured add-on slug.                |
 |    `target`     |                 The add-on target folder.                 |
-|    `image`      |              The Image-template of the addon              |
+|     `image`     |             The Image-template of the add-on.             |
 
 ## Changelog & Releases
 

--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
         description=$(jq --raw-output '.description' "${{ steps.find.outputs.config }}")
         echo "::set-output name=description::${description}"
 
-        image=$(jq --raw-output '.image' "${{ steps.find.outputs.config }}")
+        image=$(jq --raw-output '.image // empty' "${{ steps.find.outputs.config }}")
         echo "::set-output name=image::${image}"
 
     - name: ℹ️ Extract add-on architecture information

--- a/action.yaml
+++ b/action.yaml
@@ -46,6 +46,9 @@ outputs:
   target:
     description: Returns the add-on target folder name
     value: ${{ steps.find.outputs.target }}
+  image:
+    description: Image-template of the addon
+    value: ${{ steps.find.outputs.basic.image }}
 
 runs:
   using: "composite"
@@ -94,6 +97,9 @@ runs:
 
         description=$(jq --raw-output '.description' "${{ steps.find.outputs.config }}")
         echo "::set-output name=description::${description}"
+
+        image=$(jq --raw-output '.image' "${{ steps.find.outputs.config }}")
+        echo "::set-output name=image::${image}"
 
     - name: ℹ️ Extract add-on architecture information
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ outputs:
     description: Returns the add-on target folder name
     value: ${{ steps.find.outputs.target }}
   image:
-    description: Image-template of the addon
+    description: Image-template of the add-on
     value: ${{ steps.find.outputs.basic.image }}
 
 runs:


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

Hi @frenck,
I want the replace my hackish shell step with your information action and was missing the image attribute of the addon. So this PR adds an additional output with the image defined in the config.json.
