### PR TITLE
Fix always empty add-on path input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ runs:
       run: |
         if [[ -n "${{ inputs.path }}" ]]; then
           path="${{ inputs.path }}"
-          path="${config%/}"
+          path="${path%/}"
           config="${path}/config.json"
 
           if [[ ! -f "${config}" ]]; then


### PR DESCRIPTION
Good Evening,

I was integrating the action and noticed that the path input don't accept any input at all.

This should fix it by deleting the trailing '/' from the input parameter is necessary instead if putting the input to ''.