### PR TITLE
Add version attribute as action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The Action provides the following information as output:
 |     `slug`      |                The configured add-on slug.                |
 |    `target`     |                 The add-on target folder.                 |
 |     `image`     |             The Image-template of the add-on.             |
+|    `version`    |                 The version of the addon.                 |
 
 ## Changelog & Releases
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The Action provides the following information as output:
 |     `slug`      |                The configured add-on slug.                |
 |    `target`     |                 The add-on target folder.                 |
 |     `image`     |             The Image-template of the add-on.             |
-|    `version`    |                 The version of the add-on.                 |
+|    `version`    |                The version of the add-on.                 |
 
 ## Changelog & Releases
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The Action provides the following information as output:
 |     `slug`      |                The configured add-on slug.                |
 |    `target`     |                 The add-on target folder.                 |
 |     `image`     |             The Image-template of the add-on.             |
-|    `version`    |                 The version of the addon.                 |
+|    `version`    |                 The version of the add-on.                 |
 
 ## Changelog & Releases
 

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,9 @@ outputs:
   image:
     description: Image-template of the add-on
     value: ${{ steps.find.outputs.basic.image }}
+  version:
+    description: Returns the version of the add-on
+    value: ${{ steps.find.outputs.basic.version }}
 
 runs:
   using: "composite"
@@ -100,6 +103,9 @@ runs:
 
         image=$(jq --raw-output '.image // empty' "${{ steps.find.outputs.config }}")
         echo "::set-output name=image::${image}"
+
+        version=$(jq --raw-output '.version' "${{ steps.find.outputs.config }}")
+        echo "::set-output name=version::${version}"
 
     - name: ℹ️ Extract add-on architecture information
       shell: bash


### PR DESCRIPTION
During using the information addon, I was missing the version attribute. This PR adds it as additional output.