### PR TITLE
Fix `version` and `image` outputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,10 +48,10 @@ outputs:
     value: ${{ steps.find.outputs.target }}
   image:
     description: Image-template of the add-on
-    value: ${{ steps.find.outputs.basic.image }}
+    value: ${{ steps.basic.outputs.image }}
   version:
     description: Returns the version of the add-on
-    value: ${{ steps.find.outputs.basic.version }}
+    value: ${{ steps.basic.outputs.version }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Hi again 👋 

I integrated the action this weekend and found out that the `version` and `image` outputs are ''.
This PR fixes the wrong output specifiers on the action output specs 🙈 