### PR TITLE
Add missing armv7 output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The Action provides the following information as output:
 |    `target`     |                 The add-on target folder.                 |
 |     `image`     |             The Image-template of the add-on.             |
 |    `version`    |                The version of the add-on.                 |
+|     `armv7`     |  Boolean if the add-on support the `armv7` architecture.  |
 
 ## Changelog & Releases
 

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,9 @@ outputs:
   version:
     description: Returns the version of the add-on
     value: ${{ steps.basic.outputs.version }}
+  armv7:
+    description: Returns if the add-on supports the armv7 architecture
+    value: ${{ steps.architectures.outputs.armv7 }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
A new day, a new PR :)

I noticed also that the flag for `armv7` flag was not transported out of the action, so this change should fix it.
