### PR TITLE
Add support for the YAML file format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
             exit 1;
           fi
 
-          if [[ "${{ steps.information.outputs.config }}" != "test/config.json" ]]; then
+          if [[ "${{ steps.information.outputs.config }}" != "test/config.yaml" ]]; then
             echo "::error ::'config' does not have the expected value"
             exit 1;
           fi

--- a/action.yaml
+++ b/action.yaml
@@ -134,7 +134,7 @@ runs:
       id: architectures
       run: |
         architectures=$(
-          yq --no-colors eval '.arch' "${{ steps.find.outputs.config }}" \
+          yq --no-colors --output-format json  eval '.arch' "${{ steps.find.outputs.config }}" \
             | jq --raw-output --compact-output '. | sort'
         )
         echo "::set-output name=architectures::${architectures}"
@@ -147,8 +147,9 @@ runs:
           i386;
         do
           available=$(
-            yq --no-colors yq --no-colors eval ".arch[] \
-              | select(. == \"${architecture}\") | . or false" "${{ steps.find.outputs.config }}"
+            yq --no-colors eval \
+              ".arch[] | select(. == \"${architecture}\") | . or false" \
+              "${{ steps.find.outputs.config }}"
           )
           echo "::set-output name=${architecture}::${available}"
         done

--- a/action.yaml
+++ b/action.yaml
@@ -100,12 +100,12 @@ runs:
         echo "::set-output name=target::${target}"
 
         for config_ext in json yaml yml; do
-          if [[ -f "${path}/build.${config_ext}" ]]; then
-            build="${path}/build.${config_ext}"
+          if [[ -f "${target}/build.${config_ext}" ]]; then
+            build="${target}/build.${config_ext}"
           fi
         done
 
-          if [[ -z "${build+x}" ]]; then
+        if [[ -z "${build+x}" ]]; then
           echo "::error ::Could not find add-on build file"
           exit 1
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -78,12 +78,20 @@ runs:
             exit 1
           fi
         else
-          if ! find ./ -mindepth 2 -maxdepth 2 -regex ".*\config\.\(json\|yaml\|yml\)$" | head -1 | grep --silent .; then
+          if ! find \
+            ./ -mindepth 2 -maxdepth 2 \
+            -regex ".*\config\.\(json\|yaml\|yml\)$" \
+            | head -1 | grep --silent .;
+          then
             echo "::error ::Could not find add-on configuration file"
             exit 1
           fi
 
-          config=$(find ./ -mindepth 2 -maxdepth 2 -regex ".*\config\.\(json\|yaml\|yml\)$" -printf '%P\n' | head -1)
+          config=$(
+            find ./ -mindepth 2 -maxdepth 2 \
+            -regex ".*\config\.\(json\|yaml\|yml\)$" -printf '%P\n' \
+            | head -1
+          )
         fi
 
         echo "::set-output name=config::${config}"
@@ -125,7 +133,10 @@ runs:
       shell: bash
       id: architectures
       run: |
-        architectures=$(yq --no-colors eval '.arch' "${{ steps.find.outputs.config }}" | jq --raw-output --compact-output '. | sort')
+        architectures=$(
+          yq --no-colors eval '.arch' "${{ steps.find.outputs.config }}" \
+            | jq --raw-output --compact-output '. | sort'
+        )
         echo "::set-output name=architectures::${architectures}"
 
         for architecture in \
@@ -135,6 +146,9 @@ runs:
           armv7 \
           i386;
         do
-          available=$(yq --no-colors yq --no-colors eval ".arch[] | select(. == \"${architecture}\") | . or false" "${{ steps.find.outputs.config }}")
+          available=$(
+            yq --no-colors yq --no-colors eval ".arch[] \
+              | select(. == \"${architecture}\") | . or false" "${{ steps.find.outputs.config }}"
+          )
           echo "::set-output name=${architecture}::${available}"
         done

--- a/action.yaml
+++ b/action.yaml
@@ -123,7 +123,7 @@ runs:
         description=$(yq --no-colors eval '.description' "${{ steps.find.outputs.config }}")
         echo "::set-output name=description::${description}"
 
-        image=$(yq --no-colors eval '.image // empty' "${{ steps.find.outputs.config }}")
+        image=$(yq --no-colors eval '.image // ""' "${{ steps.find.outputs.config }}")
         echo "::set-output name=image::${image}"
 
         version=$(yq --no-colors eval '.version' "${{ steps.find.outputs.config }}")

--- a/action.yaml
+++ b/action.yaml
@@ -66,19 +66,24 @@ runs:
         if [[ -n "${{ inputs.path }}" ]]; then
           path="${{ inputs.path }}"
           path="${path%/}"
-          config="${path}/config.json"
 
-          if [[ ! -f "${config}" ]]; then
+          for config_ext in json yaml yml; do
+            if [[ -f "${path}/config.${config_ext}" ]]; then
+              config="${path}/config.${config_ext}"
+            fi
+          done 
+
+          if [[ -z "${config+x}" ]]; then
             echo "::error ::Could not find add-on configuration file in ${path}"
             exit 1
           fi
         else
-          if ! find ./ -mindepth 2 -maxdepth 2 -name "config.json" | grep --silent .; then
+          if ! find ./ -mindepth 2 -maxdepth 2 -regex ".*\config\.\(json\|yaml\|yml\)$" | head -1 | grep --silent .; then
             echo "::error ::Could not find add-on configuration file"
             exit 1
           fi
 
-          config=$(find ./ -mindepth 2 -maxdepth 2 -name "config.json" -printf '%P\n')
+          config=$(find ./ -mindepth 2 -maxdepth 2 -regex ".*\config\.\(json\|yaml\|yml\)$" -printf '%P\n' | head -1)
         fi
 
         echo "::set-output name=config::${config}"
@@ -86,35 +91,41 @@ runs:
         target=$(dirname "${config}")
         echo "::set-output name=target::${target}"
 
-        if [[ ! -f "${target}/build.json" ]]; then
+        for config_ext in json yaml yml; do
+          if [[ -f "${path}/build.${config_ext}" ]]; then
+            build="${path}/build.${config_ext}"
+          fi
+        done
+
+          if [[ -z "${build+x}" ]]; then
           echo "::error ::Could not find add-on build file"
           exit 1
         fi
-        echo "::set-output name=build::${target}/build.json"
+        echo "::set-output name=build::${build}"
     - name: ℹ️ Extract basic add-on information
       shell: bash
       id: basic
       run: |
-        slug=$(jq --raw-output '.slug' "${{ steps.find.outputs.config }}")
+        slug=$(yq --no-colors eval '.slug' "${{ steps.find.outputs.config }}")
         echo "::set-output name=slug::${slug}"
 
-        name=$(jq --raw-output '.name' "${{ steps.find.outputs.config }}")
+        name=$(yq --no-colors eval '.name' "${{ steps.find.outputs.config }}")
         echo "::set-output name=name::${name}"
 
-        description=$(jq --raw-output '.description' "${{ steps.find.outputs.config }}")
+        description=$(yq --no-colors eval '.description' "${{ steps.find.outputs.config }}")
         echo "::set-output name=description::${description}"
 
-        image=$(jq --raw-output '.image // empty' "${{ steps.find.outputs.config }}")
+        image=$(yq --no-colors eval '.image // empty' "${{ steps.find.outputs.config }}")
         echo "::set-output name=image::${image}"
 
-        version=$(jq --raw-output '.version' "${{ steps.find.outputs.config }}")
+        version=$(yq --no-colors eval '.version' "${{ steps.find.outputs.config }}")
         echo "::set-output name=version::${version}"
 
     - name: ℹ️ Extract add-on architecture information
       shell: bash
       id: architectures
       run: |
-        architectures=$(jq --raw-output --compact-output '.arch | sort' "${{ steps.find.outputs.config }}")
+        architectures=$(yq --no-colors eval '.arch' "${{ steps.find.outputs.config }}" | jq --raw-output --compact-output '. | sort')
         echo "::set-output name=architectures::${architectures}"
 
         for architecture in \
@@ -124,6 +135,6 @@ runs:
           armv7 \
           i386;
         do
-          available=$(jq --raw-output "(.arch | index(\"${architecture}\") // false) != false" "${{ steps.find.outputs.config }}")
+          available=$(yq --no-colors yq --no-colors eval ".arch[] | select(. == \"${architecture}\") | . or false" "${{ steps.find.outputs.config }}")
           echo "::set-output name=${architecture}::${available}"
         done

--- a/action.yaml
+++ b/action.yaml
@@ -71,7 +71,7 @@ runs:
             if [[ -f "${path}/config.${config_ext}" ]]; then
               config="${path}/config.${config_ext}"
             fi
-          done 
+          done
 
           if [[ -z "${config+x}" ]]; then
             echo "::error ::Could not find add-on configuration file in ${path}"

--- a/test/config.json
+++ b/test/config.json
@@ -1,8 +1,0 @@
-{
-  "name": "Test Add-on",
-  "version": "dev",
-  "slug": "test",
-  "description": "This is a test add-on",
-  "url": "https://github.com/frenck/action-addon-information",
-  "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"]
-}

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,3 +1,4 @@
+---
 name: Test Add-on
 version: dev
 slug: test

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,7 +4,6 @@ slug: test
 description: This is a test add-on
 url: https://github.com/frenck/action-addon-information
 arch:
-  - test
   - aarch64
   - amd64
   - armhf

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,0 +1,12 @@
+name: Test Add-on
+version: dev
+slug: test
+description: This is a test add-on
+url: https://github.com/frenck/action-addon-information
+arch:
+  - test
+  - aarch64
+  - amd64
+  - armhf
+  - armv7
+  - i386


### PR DESCRIPTION
Add support for the YAML file format for both the config & build files.

It does this by:
- Searching for `*.json`, `*.yaml`, `*.yml` files.
- Replacing `jq` with `yq`. The latter supports both YAML & JSON.